### PR TITLE
fix: compatibility issue with newer versions of Click

### DIFF
--- a/src/ekzexport/cli.py
+++ b/src/ekzexport/cli.py
@@ -47,7 +47,7 @@ def cli(ctx: click.Context, user: str, password: str):
             click.echo('  ' + os.path.join(location, 'ekzexport.json'), err=True)
         raise click.UsageError('Missing username or password')
 
-    ctx.obj = ctx.with_resource(Session(user, password))
+    ctx.obj = Session(user, password)
 
 
 @cli.command()


### PR DESCRIPTION
I was getting the following error:

```
An unexpected error occurred during execution:
  Traceback (most recent call last):

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/ekzexport/cli.py", line 162, in main
    cli()

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/core.py", line 1256, in invoke
    Command.invoke(self, ctx)

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    File "/Users/wjdj/.pyenv/versions/myenv/lib/python3.12/site-packages/ekzexport/cli.py", line 50, in cli
    ctx.obj = ctx.with_resource(Session(user, password))
              ^^^^^^^^^^^^^^^^^

  AttributeError: 'Context' object has no attribute 'with_resource'
```